### PR TITLE
Change teamleader.eu urls to focus.teamleader.eu

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
-TEAMLEADER_AUTH_URI=https://app.teamleader.eu
-TEAMLEADER_API_URI=https://api.teamleader.eu
+TEAMLEADER_AUTH_URI=https://focus.teamleader.eu
+TEAMLEADER_API_URI=https://api.focus.teamleader.eu
 TEAMLEADER_CLIENT_ID=fill_me_in
 TEAMLEADER_CLIENT_SECRET=fill_me_in
 TEAMLEADER_REDIRECT_URI=https://public_openshift_route/sync/oauth

--- a/README.md
+++ b/README.md
@@ -146,10 +146,10 @@ Coverage HTML written to dir htmlcov
 
 Teamleader has an original take on oauth2 and its token management system.
 Basically you first set up a code to be used here in the KnowledgeGraph integration:
-KnowledgeGraph integration https://marketplace.teamleader.eu/be/nl/beheer
+KnowledgeGraph integration https://marketplace.focus.teamleader.eu/be/nl/beheer
 
 More specifically for the qas environment you need to use the client_id and secret here:
-https://marketplace.teamleader.eu/be/nl/ontwikkel/integraties/b88413
+https://marketplace.focus.teamleader.eu/be/nl/ontwikkel/integraties/b88413
 
 
 Whenever you save here it invalidates the refresh_token and any backend using it must update it's
@@ -175,10 +175,10 @@ To initially bootstrap your 'code' or whenever the refresh_token is invalid and 
 ```
 Error 400: {"errors":[{"code":8,"title":"The refresh token is invalid.","status":400,"meta":{"type":"invalid_request","hint":"Token has been revoked"}}]} in handle_token_response
 
-Login into teamleader and paste code callback link in browser: https://app.teamleader.eu/oauth2/authorize?client_id=75bd9426f541ea9be95142476c458023&response_type=code&redirect_uri=https://teamleader.sitweb.eu/oauth&state=qas_secret_state
+Login into teamleader and paste code callback link in browser: https://focus.teamleader.eu/oauth2/authorize?client_id=75bd9426f541ea9be95142476c458023&response_type=code&redirect_uri=https://teamleader.sitweb.eu/oauth&state=qas_secret_state
 ```
 
-This means you need to login into teamleader.eu with an admin account and then paste the above link in your browser. Then the teamleader server will make a call to the redirect_uri specified which must match the one specified on the integration page and here you will see the code that is passed.
+This means you need to login into focus.teamleader.eu with an admin account and then paste the above link in your browser. Then the teamleader server will make a call to the redirect_uri specified which must match the one specified on the integration page and here you will see the code that is passed.
 
 
 

--- a/config.yml.tst
+++ b/config.yml.tst
@@ -3,8 +3,8 @@ viaa:
     level: DEBUG
 app:
   teamleader:
-    auth_uri: 'https://app.teamleader.eu'
-    api_uri: 'https://api.teamleader.eu'
+    auth_uri: 'https://focus.teamleader.eu'
+    api_uri: 'https://api.focus.teamleader.eu'
     client_id: 'fill_me_in'
     client_secret: 'fill_me_in'
     redirect_uri: 'https://public_openshift_route/sync/oauth'

--- a/tests/integration/test_sync.py
+++ b/tests/integration/test_sync.py
@@ -4,7 +4,7 @@
 from unittest.mock import patch, MagicMock
 from app.app import App
 
-API_URL = 'https://api.teamleader.eu'
+API_URL = 'https://api.focus.teamleader.eu'
 
 
 class MockResponse:

--- a/tests/unit/comm/test_teamleader_client.py
+++ b/tests/unit/comm/test_teamleader_client.py
@@ -4,7 +4,7 @@
 from unittest.mock import patch, Mock, MagicMock
 from app.app import App
 
-API_URL = 'https://api.teamleader.eu'
+API_URL = 'https://api.focus.teamleader.eu'
 
 
 class MockResponse:


### PR DESCRIPTION
The Teamleader application has been renamed to Teamleader Focus, more info about this can be found [here](https://www.teamleader.eu/blog/new-names-teamleader-focus-orbit). This product name change also means that the application, api, marketplace, etc. have a new home under [focus.teamleader.eu](https://focus.teamleader.eu).

This PR changes the Teamleader URLs in this repo to point to [focus.teamleader.eu](https://focus.teamleader.eu). The switch to these new URLs isn't urgent though, the old URLs will remain available for some time.